### PR TITLE
⏺ Enhance prompt

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:starship.rs)"
+    ]
+  }
+}

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,7 +1,4 @@
 #[derive(Debug, Eq, PartialEq)]
-pub struct Hash(pub String);
-
-#[derive(Debug, Eq, PartialEq)]
 pub struct Branch(pub String);
 
 #[derive(Debug, Eq, PartialEq)]

--- a/src/resources/zshrc.sh
+++ b/src/resources/zshrc.sh
@@ -36,8 +36,7 @@ function chpwd_update_git_vars() {
 function update_current_git_vars() {
 	unset __CURRENT_GIT_STATUS
 
-	# ejs todo: where is the rust executable / bin dir?
-	_GIT_STATUS=`git status --porcelain --branch &> /dev/null | gitstatus`
+	_GIT_STATUS=`git status --porcelain --branch 2>/dev/null | gitstatus`
 	__CURRENT_GIT_STATUS=("${(@s: :)_GIT_STATUS}")
 	GIT_BRANCH=$__CURRENT_GIT_STATUS[1]
 	GIT_AHEAD=$__CURRENT_GIT_STATUS[2]
@@ -46,12 +45,13 @@ function update_current_git_vars() {
 	GIT_CONFLICTS=$__CURRENT_GIT_STATUS[5]
 	GIT_CHANGED=$__CURRENT_GIT_STATUS[6]
 	GIT_UNTRACKED=$__CURRENT_GIT_STATUS[7]
+	GIT_STASH=$(git stash list 2>/dev/null | wc -l | tr -d ' ')
 }
 
 git_super_status() {
 	precmd_update_git_vars
 	if [ -n "$__CURRENT_GIT_STATUS" ]; then
-		STATUS="$ZSH_THEME_GIT_PROMPT_PREFIX$ZSH_THEME_GIT_PROMPT_BRANCH$GIT_BRANCH%{${reset_color}%}"
+		STATUS="$ZSH_THEME_GIT_PROMPT_PREFIX$ZSH_THEME_GIT_PROMPT_BRANCH$ZSH_THEME_GIT_PROMPT_BRANCH_SYMBOL$GIT_BRANCH%{${reset_color}%}"
 		if [ "$GIT_BEHIND" -ne "0" ]; then
 			STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_BEHIND$GIT_BEHIND%{${reset_color}%}"
 		fi
@@ -71,6 +71,9 @@ git_super_status() {
 		if [ "$GIT_UNTRACKED" -ne "0" ]; then
 			STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_UNTRACKED%{${reset_color}%}"
 		fi
+		if [ "$GIT_STASH" -ne "0" ]; then
+			STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_STASH$GIT_STASH%{${reset_color}%}"
+		fi
 		if [ "$GIT_CHANGED" -eq "0" ] && [ "$GIT_CONFLICTS" -eq "0" ] && [ "$GIT_STAGED" -eq "0" ] && [ "$GIT_UNTRACKED" -eq "0" ]; then
 			STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_CLEAN"
 		fi
@@ -84,10 +87,12 @@ ZSH_THEME_GIT_PROMPT_PREFIX="("
 ZSH_THEME_GIT_PROMPT_SUFFIX=")"
 ZSH_THEME_GIT_PROMPT_SEPARATOR="|"
 ZSH_THEME_GIT_PROMPT_BRANCH="%{$fg_bold[magenta]%}"
+ZSH_THEME_GIT_PROMPT_BRANCH_SYMBOL="%{ %G%}"
 ZSH_THEME_GIT_PROMPT_STAGED="%{$fg[red]%}%{●%G%}"
 ZSH_THEME_GIT_PROMPT_CONFLICTS="%{$fg[red]%}%{✖%G%}"
 ZSH_THEME_GIT_PROMPT_CHANGED="%{$fg[blue]%}%{✚%G%}"
 ZSH_THEME_GIT_PROMPT_BEHIND="%{↓%G%}"
 ZSH_THEME_GIT_PROMPT_AHEAD="%{↑%G%}"
 ZSH_THEME_GIT_PROMPT_UNTRACKED="%{…%G%}"
+ZSH_THEME_GIT_PROMPT_STASH="%{$fg[yellow]%}%{󰏗%G%}"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[green]%}%{✔%G%}"


### PR DESCRIPTION
  1. Removed dead code - data.rs:2 - removed unused Hash struct

  2. Added nerd font branch symbol - zshrc.sh:91
  - New variable: ZSH_THEME_GIT_PROMPT_BRANCH_SYMBOL="%{ %G%}"
  - The `` is the nerd font git branch icon
  - Displayed before branch name: ( main instead of (main

  3. Added stash count - zshrc.sh:49,75-77,98
  - Retrieves stash count: git stash list 2>/dev/null | wc -l
  - New variable: ZSH_THEME_GIT_PROMPT_STASH="%{$fg[yellow]%}%{󰏗%G%}"
  - The 󰏗 is a nerd font stash/inbox icon (yellow)
  - Shows count when stashes exist, e.g., 󰏗2

  Example prompt appearance:
  ( main↑2|●1✚3󰏗2)
  ^ branch icon, branch name, 2 ahead, separator, 1 staged, 3 changed, 2 stashes

  Users without nerd fonts can override ZSH_THEME_GIT_PROMPT_BRANCH_SYMBOL and ZSH_THEME_GIT_PROMPT_STASH in their .zshrc to use plain text symbols like $ for stash.